### PR TITLE
Fix azure pipelines warning

### DIFF
--- a/src/v2/task.json
+++ b/src/v2/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 0
+        "Patch": 1
     },
     "instanceNameFormat": "Queue build(s) $(buildDefinitionName)",
     "minimumAgentVersion": "-",
@@ -128,7 +128,13 @@
         }
     ],
     "execution": {
-        "Node": {
+        "Node10": {
+            "target": "task/queue-build.task.js"
+        },
+        "Node16": {
+            "target": "task/queue-build.task.js"
+        },
+        "Node20_1": {
             "target": "task/queue-build.task.js"
         }
     }

--- a/src/v2/task.json
+++ b/src/v2/task.json
@@ -8,8 +8,8 @@
     "author": "jb",
     "version": {
         "Major": 2,
-        "Minor": 1,
-        "Patch": 1
+        "Minor": 2,
+        "Patch": 0
     },
     "instanceNameFormat": "Queue build(s) $(buildDefinitionName)",
     "minimumAgentVersion": "-",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "queue-build",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "name": "Queue Build(s) Task",
     "description": "A build/release task that queues new build(s).",
     "publisher": "jb",


### PR DESCRIPTION
Fixes: ##[warning]Task 'Queue Build(s)' version 2 (queue-build@2) is dependent on a Node version (6) that is end-of-life. Contact the extension owner for an updated version of the task. Task maintainers should review Node upgrade guidance: https://aka.ms/node-runner-guidance
